### PR TITLE
add concurrency to github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,16 @@ on:
 
 # Permissions are granted per job to follow principle of least privilege
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build, lint and unit tests
     runs-on: ubuntu-latest
     permissions:
-      contents: read  # Read repository contents
+      contents: read # Read repository contents
     outputs:
       plugin-id: ${{ steps.metadata.outputs.plugin-id }}
       plugin-version: ${{ steps.metadata.outputs.plugin-version }}
@@ -45,7 +49,7 @@ jobs:
         run: npm run lint
       - name: Unit tests with coverage
         run: npm run test:ci
-      
+
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4
         with:
@@ -154,8 +158,8 @@ jobs:
     name: e2e test ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read        # Read repository contents
-      pull-requests: write  # Upload test report artifacts to PRs
+      contents: read # Read repository contents
+      pull-requests: write # Upload test report artifacts to PRs
     steps:
       - uses: actions/checkout@v4
         with:
@@ -227,8 +231,8 @@ jobs:
     needs: [playwright-tests]
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # Deploy to GitHub Pages
-      pull-requests: write  # Comment on PRs with report links
+      contents: write # Deploy to GitHub Pages
+      pull-requests: write # Comment on PRs with report links
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This should stop any in-progress workflows when successive commits are pushed to a branch.
