### PR TITLE
feat(recommender): added help buttons to recommender page

### DIFF
--- a/src/components/HelpFooter/HelpFooter.tsx
+++ b/src/components/HelpFooter/HelpFooter.tsx
@@ -1,0 +1,215 @@
+import React, { useState } from 'react';
+import { Icon, useTheme2, Modal } from '@grafana/ui';
+import { config } from '@grafana/runtime';
+import { getHelpFooterStyles } from '../../styles/help-footer.styles';
+
+interface HelpFooterProps {
+  className?: string;
+}
+
+export const HelpFooter: React.FC<HelpFooterProps> = ({ className }) => {
+  const theme = useTheme2();
+  const styles = getHelpFooterStyles(theme);
+  const [isHelpModalOpen, setIsHelpModalOpen] = useState(false);
+
+  const handleKeyboardShortcuts = () => {
+    setIsHelpModalOpen(true);
+  };
+
+  const handleCloseHelpModal = () => {
+    setIsHelpModalOpen(false);
+  };
+
+  const helpButtons = [
+    {
+      key: 'documentation',
+      label: 'Documentation',
+      icon: 'file-alt' as const,
+      href: 'https://grafana.com/docs/grafana/latest/?utm_source=grafana_footer',
+    },
+    {
+      key: 'support',
+      label: 'Support',
+      icon: 'question-circle' as const,
+      href: 'https://grafana.com/products/enterprise/?utm_source=grafana_footer',
+    },
+    {
+      key: 'community',
+      label: 'Community',
+      icon: 'comments-alt' as const,
+      href: 'https://community.grafana.com/?utm_source=grafana_footer',
+    },
+    {
+      key: 'enterprise',
+      label: 'Enterprise',
+      icon: 'external-link-alt' as const,
+      href: 'https://grafana.com/products/enterprise/?utm_source=grafana_footer',
+    },
+    {
+      key: 'download',
+      label: 'Download',
+      icon: 'download-alt' as const,
+      href: 'https://grafana.com/grafana/download?utm_source=grafana_footer',
+    },
+    {
+      key: 'shortcuts',
+      label: 'Shortcuts',
+      icon: 'keyboard' as const,
+      onClick: handleKeyboardShortcuts,
+    },
+  ];
+
+  return (
+    <div className={`${styles.helpFooter} ${className || ''}`}>
+      <div className={styles.helpButtons}>
+        {helpButtons.map((button) => {
+          const ButtonComponent = button.href ? 'a' : 'button';
+          const buttonProps = button.href
+            ? {
+                href: button.href,
+                target: '_blank',
+                rel: 'noopener noreferrer',
+              }
+            : {
+                onClick: button.onClick,
+                type: 'button' as const,
+              };
+
+          return (
+            <ButtonComponent key={button.key} className={styles.helpButton} {...buttonProps}>
+              <div className={styles.helpButtonContent}>
+                <Icon name={button.icon} size="sm" className={styles.helpButtonIcon} />
+                <span className={styles.helpButtonText}>{button.label}</span>
+              </div>
+            </ButtonComponent>
+          );
+        })}
+      </div>
+
+      {/* Version info */}
+      {config.buildInfo && (
+        <div className={styles.versionInfo}>
+          <div className={styles.versionText}>
+            Grafana v{config.buildInfo.version} ({config.buildInfo.commit?.substring(0, 10) || 'unknown'})
+          </div>
+        </div>
+      )}
+
+      {/* Keyboard Shortcuts Modal */}
+      {isHelpModalOpen && (
+        <Modal title="Keyboard Shortcuts" isOpen={isHelpModalOpen} onDismiss={handleCloseHelpModal}>
+          <div style={{ minWidth: '500px', padding: '16px' }}>
+            <div style={{ marginBottom: '16px' }}>
+              <h3 style={{ marginBottom: '8px' }}>Global Shortcuts</h3>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', gap: '8px', fontSize: '14px' }}>
+                <div>
+                  <kbd
+                    style={{
+                      padding: '2px 6px',
+                      backgroundColor: theme.colors.background.secondary,
+                      border: `1px solid ${theme.colors.border.medium}`,
+                      borderRadius: '3px',
+                    }}
+                  >
+                    ?
+                  </kbd>
+                </div>
+                <div>Show all keyboard shortcuts</div>
+                <div>
+                  <kbd
+                    style={{
+                      padding: '2px 6px',
+                      backgroundColor: theme.colors.background.secondary,
+                      border: `1px solid ${theme.colors.border.medium}`,
+                      borderRadius: '3px',
+                    }}
+                  >
+                    g h
+                  </kbd>
+                </div>
+                <div>Go to Home Dashboard</div>
+                <div>
+                  <kbd
+                    style={{
+                      padding: '2px 6px',
+                      backgroundColor: theme.colors.background.secondary,
+                      border: `1px solid ${theme.colors.border.medium}`,
+                      borderRadius: '3px',
+                    }}
+                  >
+                    g d
+                  </kbd>
+                </div>
+                <div>Go to Dashboards</div>
+                <div>
+                  <kbd
+                    style={{
+                      padding: '2px 6px',
+                      backgroundColor: theme.colors.background.secondary,
+                      border: `1px solid ${theme.colors.border.medium}`,
+                      borderRadius: '3px',
+                    }}
+                  >
+                    esc
+                  </kbd>
+                </div>
+                <div>Exit edit/setting views</div>
+              </div>
+            </div>
+
+            <div style={{ marginBottom: '16px' }}>
+              <h3 style={{ marginBottom: '8px' }}>Dashboard Shortcuts</h3>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 2fr', gap: '8px', fontSize: '14px' }}>
+                <div>
+                  <kbd
+                    style={{
+                      padding: '2px 6px',
+                      backgroundColor: theme.colors.background.secondary,
+                      border: `1px solid ${theme.colors.border.medium}`,
+                      borderRadius: '3px',
+                    }}
+                  >
+                    d r
+                  </kbd>
+                </div>
+                <div>Refresh all panels</div>
+                <div>
+                  <kbd
+                    style={{
+                      padding: '2px 6px',
+                      backgroundColor: theme.colors.background.secondary,
+                      border: `1px solid ${theme.colors.border.medium}`,
+                      borderRadius: '3px',
+                    }}
+                  >
+                    d s
+                  </kbd>
+                </div>
+                <div>Dashboard settings</div>
+                <div>
+                  <kbd
+                    style={{
+                      padding: '2px 6px',
+                      backgroundColor: theme.colors.background.secondary,
+                      border: `1px solid ${theme.colors.border.medium}`,
+                      borderRadius: '3px',
+                    }}
+                  >
+                    d v
+                  </kbd>
+                </div>
+                <div>Toggle view mode</div>
+              </div>
+            </div>
+
+            <div
+              style={{ fontSize: '12px', color: theme.colors.text.secondary, marginTop: '16px', fontStyle: 'italic' }}
+            >
+              This is a simplified view. You can replace this with Grafana&apos;s full HelpModal component.
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+};

--- a/src/components/HelpFooter/README.md
+++ b/src/components/HelpFooter/README.md
@@ -1,0 +1,70 @@
+# HelpFooter Component
+
+A modular footer component that provides quick access to Grafana help resources and displays version information.
+
+## Features
+
+- **Help Buttons Grid**: 2-column grid layout with 6 help buttons
+  - Documentation (links to Grafana documentation)
+  - Support (links to Grafana support page)
+  - Community (links to Grafana community forum)
+  - Enterprise (links to Grafana enterprise info)
+  - Download (links to Grafana downloads)
+  - Keyboard Shortcuts (triggers native shortcuts modal)
+
+- **Version Display**: Shows current Grafana version and commit hash
+- **Grafana Design System**: Uses secondary small button styling for consistency
+- **Accessibility**: Proper focus states and keyboard navigation
+- **Responsive**: Grid layout adapts to container width
+
+## Usage
+
+```tsx
+import { HelpFooter } from '../HelpFooter';
+
+// Basic usage
+<HelpFooter />
+
+// With custom className
+<HelpFooter className="custom-footer-class" />
+```
+
+## Styling
+
+The component uses Grafana's secondary button style (small size) and follows the design system patterns. Styling is handled in `src/styles/help-footer.styles.ts` using the `createSecondaryButton` utility from `button-utils.ts`.
+
+## Keyboard Shortcuts Implementation
+
+The component currently includes a **simplified keyboard shortcuts modal** as a placeholder. To integrate Grafana's full HelpModal:
+
+1. **Copy the full HelpModal implementation** from `public/app/core/components/help/HelpModal.tsx` in the Grafana repository
+2. **Replace the placeholder modal** in `HelpFooter.tsx` with the full implementation
+3. **Import required dependencies** like `@grafana/i18n` and any missing utilities
+
+### Current Implementation
+
+```tsx
+// Simple placeholder modal with basic shortcuts
+<Modal title="Keyboard Shortcuts" isOpen={isOpen} onDismiss={onClose}>
+  {/* Simplified shortcuts display */}
+</Modal>
+```
+
+### Full Implementation (to replace)
+
+```tsx
+// Import the complete HelpModal from Grafana core
+import { HelpModal } from './path/to/HelpModal';
+
+// Use in component
+{
+  isHelpModalOpen && <HelpModal onDismiss={handleCloseHelpModal} />;
+}
+```
+
+## Files
+
+- `HelpFooter.tsx` - Main component with modal state management
+- `../../styles/help-footer.styles.ts` - Emotion CSS styles using secondary button utility
+- `index.ts` - Barrel export
+- `README.md` - This documentation

--- a/src/components/HelpFooter/index.ts
+++ b/src/components/HelpFooter/index.ts
@@ -1,0 +1,1 @@
+export { HelpFooter } from './HelpFooter';

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -5,6 +5,7 @@ import { Icon, useStyles2, Card } from '@grafana/ui';
 import logoSvg from '../../img/logo.svg';
 import { SkeletonLoader } from '../SkeletonLoader';
 import { FeedbackButton } from '../FeedbackButton/FeedbackButton';
+import { HelpFooter } from '../HelpFooter';
 import { locationService } from '@grafana/runtime';
 
 // Import refactored context system
@@ -377,6 +378,9 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
             )}
           </div>
         )}
+
+        {/* Help Footer */}
+        <HelpFooter />
       </div>
     </div>
   );

--- a/src/styles/help-footer.styles.ts
+++ b/src/styles/help-footer.styles.ts
@@ -1,0 +1,77 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { createSecondaryButton } from './button-utils';
+
+export const getHelpFooterStyles = (theme: GrafanaTheme2) => ({
+  helpFooter: css({
+    marginTop: 'auto',
+    padding: theme.spacing(2),
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+    backgroundColor: theme.colors.background.canvas,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+  }),
+  helpButtons: css({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(2, 1fr)',
+    gap: theme.spacing(0.75),
+    width: '100%',
+  }),
+  helpButton: css([
+    createSecondaryButton(theme, { size: 'sm' }),
+    {
+      '&&': {
+        // Double ampersand increases specificity to override createButtonBase
+        justifyContent: 'flex-start',
+        textAlign: 'left',
+      },
+      textDecoration: 'none',
+      minHeight: '32px',
+
+      // Override the default secondary button hover to be more subtle
+      '&:hover:not(:disabled)': {
+        backgroundColor: theme.colors.action.hover,
+        borderColor: theme.colors.border.medium,
+        transform: 'translateY(-1px)',
+        boxShadow: theme.shadows.z1,
+        textDecoration: 'none',
+        color: theme.colors.text.primary,
+      },
+    },
+  ]),
+  helpButtonContent: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    width: '100%',
+    minWidth: 0,
+  }),
+  helpButtonIcon: css({
+    color: theme.colors.text.secondary,
+    flexShrink: 0,
+  }),
+  helpButtonText: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontWeight: theme.typography.fontWeightRegular,
+    color: theme.colors.text.primary,
+    flex: 1,
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  }),
+  versionInfo: css({
+    display: 'flex',
+    justifyContent: 'center',
+    paddingTop: theme.spacing(1),
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+  }),
+  versionText: css({
+    fontSize: '11px',
+    color: theme.colors.text.secondary,
+    fontWeight: theme.typography.fontWeightRegular,
+    textAlign: 'center',
+    lineHeight: 1.3,
+  }),
+});


### PR DESCRIPTION
This pull request introduces a new, modular `HelpFooter` component to the codebase, providing users with quick access to Grafana help resources, displaying version information, and offering a keyboard shortcuts modal. The component is styled according to Grafana's design system and is integrated into the main context panel. Supporting documentation and styling files are also included.

**New HelpFooter Component and Integration**

* Added the `HelpFooter` React component in `HelpFooter.tsx`, featuring a grid of help buttons (Documentation, Support, Community, Enterprise, Download, and Keyboard Shortcuts), version information display, and a modal for keyboard shortcuts. The modal currently uses a simplified implementation and includes instructions for replacing it with Grafana's full HelpModal.
* Integrated the `HelpFooter` into the context panel by importing and rendering it in `context-panel.tsx`, ensuring it displays at the bottom of the panel. [[1]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769R8) [[2]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769R381-R383)
* Created a barrel export for the new component in `index.ts` for easier imports elsewhere in the codebase.

**Styling and Documentation**

* Added `help-footer.styles.ts` to provide Emotion CSS styles for the `HelpFooter`, using Grafana's secondary button utility and ensuring responsive, accessible design.
* Included a comprehensive `README.md` documenting the features, usage, styling, and keyboard shortcuts modal implementation of the `HelpFooter` component.

<img width="579" height="954" alt="Screenshot 2025-08-22 at 11 34 12" src="https://github.com/user-attachments/assets/65230f0d-5861-4992-b194-648df21706a5" />
