### PR TITLE
add dev mode, ability to load components page

### DIFF
--- a/src/components/AppConfig/ConfigurationForm.tsx
+++ b/src/components/AppConfig/ConfigurationForm.tsx
@@ -27,11 +27,15 @@ type State = {
   isDocsPasswordSet: boolean;
   // Auto-launch tutorial URL (for demo scenarios)
   tutorialUrl: string;
+  // Dev mode enables loading of the components page for testing of proper rendering of components
+  devMode: boolean;
 };
 
 export interface ConfigurationFormProps extends PluginConfigPageProps<AppPluginMeta<JsonData>> {}
 
 const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const showDevModeInput = urlParams.get('dev') === 'true';
   const s = useStyles2(getStyles);
   const { enabled, pinned, jsonData, secureJsonFields } = plugin.meta;
   const [state, setState] = useState<State>({
@@ -41,6 +45,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
     docsPassword: '',
     isDocsPasswordSet: Boolean(secureJsonFields && (secureJsonFields as any).docsPassword),
     tutorialUrl: jsonData?.tutorialUrl || DEFAULT_TUTORIAL_URL,
+    devMode: jsonData?.devMode || false,
   });
   const [isSaving, setIsSaving] = useState(false);
 
@@ -90,6 +95,13 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
     });
   };
 
+  const onChangeDevMode = (event: ChangeEvent<HTMLInputElement>) => {
+    setState({
+      ...state,
+      devMode: event.target.checked,
+    });
+  };
+
   const onSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     setIsSaving(true);
@@ -101,6 +113,7 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
         docsBaseUrl: state.docsBaseUrl,
         docsUsername: state.docsUsername,
         tutorialUrl: state.tutorialUrl,
+        devMode: state.devMode,
       };
 
       await updatePluginSettings(plugin.meta.id, {
@@ -206,6 +219,13 @@ const ConfigurationForm = ({ plugin }: ConfigurationFormProps) => {
             onChange={onChangeTutorialUrl}
           />
         </Field>
+
+        {/* Dev Mode */}
+        {showDevModeInput && (
+          <Field label="Dev Mode" description="Enable dev mode" className={s.marginTop}>
+            <Input type="checkbox" id="dev-mode" checked={state.devMode} onChange={onChangeDevMode} />
+          </Field>
+        )}
 
         <div className={s.marginTop}>
           <Button type="submit" data-testid={testIds.appConfig.submit} disabled={isSubmitDisabled || isSaving}>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,7 @@ export const DEFAULT_DOCS_PASSWORD = '';
 export const DEFAULT_TUTORIAL_URL = '';
 export const DEFAULT_TERMS_ACCEPTED = false;
 export const TERMS_VERSION = '1.0.0';
+export const DEFAULT_DEV_MODE = false;
 
 // Configuration interface
 export interface DocsPluginConfig {
@@ -21,6 +22,7 @@ export interface DocsPluginConfig {
   // Terms and Conditions
   acceptedTermsAndConditions?: boolean;
   termsVersion?: string;
+  devMode?: boolean;
 }
 
 // Helper functions to get configuration values with defaults
@@ -32,6 +34,7 @@ export const getConfigWithDefaults = (config: DocsPluginConfig): Required<DocsPl
   tutorialUrl: config.tutorialUrl || DEFAULT_TUTORIAL_URL,
   acceptedTermsAndConditions: config.acceptedTermsAndConditions ?? DEFAULT_TERMS_ACCEPTED,
   termsVersion: config.termsVersion || TERMS_VERSION,
+  devMode: config.devMode || DEFAULT_DEV_MODE,
 });
 
 export const isRecommenderEnabled = (config: DocsPluginConfig): boolean => {
@@ -47,6 +50,7 @@ export const getDocsPassword = (config: DocsPluginConfig) => getConfigWithDefaul
 export const getTutorialUrl = (config: DocsPluginConfig) => getConfigWithDefaults(config).tutorialUrl;
 export const getTermsAccepted = (config: DocsPluginConfig) => getConfigWithDefaults(config).acceptedTermsAndConditions;
 export const getTermsVersion = (config: DocsPluginConfig) => getConfigWithDefaults(config).termsVersion;
+export const getDevMode = (config: DocsPluginConfig) => getConfigWithDefaults(config).devMode;
 
 // Legacy exports for backward compatibility
 export const RECOMMENDER_SERVICE_URL = DEFAULT_RECOMMENDER_SERVICE_URL;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,14 +3,14 @@ import pluginJson from './plugin.json';
 export const PLUGIN_BASE_URL = `/a/${pluginJson.id}`;
 
 // Default configuration values
-export const DEFAULT_RECOMMENDER_SERVICE_URL = 'https://recommender.grafana-dev.com';
+export const DEFAULT_DEV_MODE = false;
 export const DEFAULT_DOCS_BASE_URL = 'https://grafana.com';
 export const DEFAULT_DOCS_USERNAME = '';
 export const DEFAULT_DOCS_PASSWORD = '';
-export const DEFAULT_TUTORIAL_URL = '';
+export const DEFAULT_RECOMMENDER_SERVICE_URL = 'https://recommender.grafana-dev.com';
 export const DEFAULT_TERMS_ACCEPTED = false;
+export const DEFAULT_TUTORIAL_URL = '';
 export const TERMS_VERSION = '1.0.0';
-export const DEFAULT_DEV_MODE = false;
 
 // Configuration interface
 export interface DocsPluginConfig {

--- a/src/utils/context/context.service.ts
+++ b/src/utils/context/context.service.ts
@@ -1040,7 +1040,7 @@ export class ContextService {
     if (configWithDefaults.devMode) {
       bundledRecommendations.push({
         title: 'Components',
-        url: 'https://grafana.com/components',
+        url: 'https://grafana.com/components/',
         type: 'docs-page',
         summary: 'Components page',
       });

--- a/src/utils/context/context.service.ts
+++ b/src/utils/context/context.service.ts
@@ -271,8 +271,7 @@ export class ContextService {
         };
       }
 
-      const bundledRecommendations = this.getBundledInteractiveRecommendations(contextData);
-
+      const bundledRecommendations = this.getBundledInteractiveRecommendations(contextData, pluginConfig);
       if (!isRecommenderEnabled(pluginConfig)) {
         const fallbackResult = await this.getFallbackRecommendations(contextData, bundledRecommendations);
         return {
@@ -286,7 +285,7 @@ export class ContextService {
       return this.getExternalRecommendations(contextData, pluginConfig, bundledRecommendations);
     } catch (error) {
       console.warn('Failed to fetch recommendations:', error);
-      const bundledRecommendations = this.getBundledInteractiveRecommendations(contextData);
+      const bundledRecommendations = this.getBundledInteractiveRecommendations(contextData, pluginConfig);
       const fallbackResult = await this.getFallbackRecommendations(contextData, bundledRecommendations);
       return {
         ...fallbackResult,
@@ -1031,8 +1030,21 @@ export class ContextService {
    * Get bundled interactive recommendations from index.json file
    * Filters based on current URL to show contextually relevant interactives
    */
-  private static getBundledInteractiveRecommendations(contextData: ContextData): Recommendation[] {
+  private static getBundledInteractiveRecommendations(
+    contextData: ContextData,
+    pluginConfig: DocsPluginConfig
+  ): Recommendation[] {
+    const configWithDefaults = getConfigWithDefaults(pluginConfig);
     const bundledRecommendations: Recommendation[] = [];
+
+    if (configWithDefaults.devMode) {
+      bundledRecommendations.push({
+        title: 'Components',
+        url: 'https://grafana.com/components',
+        type: 'docs-page',
+        summary: 'Components page',
+      });
+    }
 
     try {
       // Load the index.json file that contains metadata for all bundled interactives

--- a/src/utils/docs-retrieval/content-fetcher.ts
+++ b/src/utils/docs-retrieval/content-fetcher.ts
@@ -227,13 +227,18 @@ async function fetchRawHtml(url: string, options: ContentFetchOptions): Promise<
               const baseHost = new URL(docsBase).host;
               return host === baseHost;
             }
-            return u.includes('/docs/') || u.includes('/tutorials/');
+            return u.includes('/docs/') || u.includes('/tutorials/') || u.includes('/components/');
           } catch {
             return false;
           }
         };
 
-        if (isDocsHost(response.url) && (response.url.includes('/docs/') || response.url.includes('/tutorials/'))) {
+        if (
+          isDocsHost(response.url) &&
+          (response.url.includes('/docs/') ||
+            response.url.includes('/tutorials/') ||
+            response.url.includes('/components/'))
+        ) {
           const finalUnstyledUrl = getUnstyledContentUrl(response.url);
           if (finalUnstyledUrl !== response.url) {
             try {

--- a/src/utils/docs-retrieval/content-fetcher.ts
+++ b/src/utils/docs-retrieval/content-fetcher.ts
@@ -207,7 +207,7 @@ async function fetchRawHtml(url: string, options: ContentFetchOptions): Promise<
   let redirectInfo: string | null = null;
 
   try {
-    const response = await fetch(url, fetchOptions);
+    const response = await fetch(replaceRecommendationBaseUrl(url, options.docsBaseUrl), fetchOptions);
 
     // Log redirect information if the final URL is different
     if (response.url && response.url !== url) {
@@ -237,7 +237,10 @@ async function fetchRawHtml(url: string, options: ContentFetchOptions): Promise<
           const finalUnstyledUrl = getUnstyledContentUrl(response.url);
           if (finalUnstyledUrl !== response.url) {
             try {
-              const unstyledResponse = await fetch(finalUnstyledUrl, fetchOptions);
+              const unstyledResponse = await fetch(
+                replaceRecommendationBaseUrl(finalUnstyledUrl, options.docsBaseUrl),
+                fetchOptions
+              );
               if (unstyledResponse.ok) {
                 const unstyledHtml = await unstyledResponse.text();
                 if (unstyledHtml && unstyledHtml.trim()) {
@@ -280,7 +283,10 @@ async function fetchRawHtml(url: string, options: ContentFetchOptions): Promise<
           if (baseUrlMatch) {
             const fullRedirectUrl = baseUrlMatch[1] + location;
             try {
-              const redirectResponse = await fetch(fullRedirectUrl, fetchOptions);
+              const redirectResponse = await fetch(
+                replaceRecommendationBaseUrl(fullRedirectUrl, options.docsBaseUrl),
+                fetchOptions
+              );
               if (redirectResponse.ok) {
                 const html = await redirectResponse.text();
                 if (html && html.trim()) {
@@ -663,4 +669,12 @@ function findCurrentMilestoneFromUrl(url: string, milestones: Milestone[]): numb
 function urlsMatch(url1: string, url2: string): boolean {
   const normalize = (u: string) => u.replace(/\/$/, '').toLowerCase();
   return normalize(url1) === normalize(url2);
+}
+
+/**
+ * replace recommendation base url with the base url from the config
+ * ensures trailing slash and unstyled.html is added to the url
+ */
+function replaceRecommendationBaseUrl(url: string, docsBaseUrl: string | undefined): string {
+  return url.replace('https://grafana.com', docsBaseUrl || '');
 }

--- a/src/utils/docs-retrieval/content-fetcher.ts
+++ b/src/utils/docs-retrieval/content-fetcher.ts
@@ -678,7 +678,6 @@ function urlsMatch(url1: string, url2: string): boolean {
 
 /**
  * replace recommendation base url with the base url from the config
- * ensures trailing slash and unstyled.html is added to the url
  */
 function replaceRecommendationBaseUrl(url: string, docsBaseUrl: string | undefined): string {
   return url.replace('https://grafana.com', docsBaseUrl || '');


### PR DESCRIPTION
for https://github.com/grafana/docs-plugin/issues/122

- Adds an additional setting called "Dev mode" that is hidden on the plugin configuration page unless the `?dev=true` param is in the URL. When enabled, the components page is always recommended first to facilitate easy testing of component rendering. Note, https://grafana.com/components/ is not available publicly, dev mode is intended only for working with the website locally.
- Replaces the domain of the request to match the Docs base URL as set on the configuration page.

To test, clear your localStorage, run the app locally, visit http://localhost:3000/plugins/grafana-grafanadocsplugin-app?dev=true, enable dev mode and follow the steps as shown in the recordings.

Before:

https://github.com/user-attachments/assets/1bf975eb-850b-4990-a9fe-d1f85e1e09e2

After:


https://github.com/user-attachments/assets/6c9ac9d6-dc46-4fc2-9d95-0f73f8b578ad



