### PR TITLE
fix(ui): Fix blue banner appearing for cloud users on install

### DIFF
--- a/src/components/AppConfig/TermsAndConditions.tsx
+++ b/src/components/AppConfig/TermsAndConditions.tsx
@@ -1,10 +1,9 @@
 import React, { useState, ChangeEvent, useEffect } from 'react';
 import { Button, useStyles2, FieldSet, Switch, Text, Alert } from '@grafana/ui';
 import { AppPluginMeta, GrafanaTheme2, PluginConfigPageProps } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { css } from '@emotion/css';
 import { testIds } from '../testIds';
-import { DocsPluginConfig, TERMS_VERSION } from '../../constants';
+import { DocsPluginConfig, TERMS_VERSION, getConfigWithDefaults } from '../../constants';
 import { TERMS_AND_CONDITIONS_CONTENT } from './terms-content';
 import { updatePluginSettings } from '../../utils/utils.plugin';
 
@@ -14,37 +13,22 @@ type JsonData = DocsPluginConfig & {
 
 export interface TermsAndConditionsProps extends PluginConfigPageProps<AppPluginMeta<JsonData>> {}
 
-/**
- * Get platform-specific default for recommender enabled state
- * Cloud: enabled by default (always online)
- * OSS: disabled by default (might be offline)
- */
-const getPlatformSpecificDefault = (): boolean => {
-  try {
-    const isCloud = config.bootData.settings.buildInfo.versionString.startsWith('Grafana Cloud');
-    return isCloud; // Cloud = true (enabled), OSS = false (disabled)
-  } catch (error) {
-    console.warn('Failed to detect platform, defaulting to disabled:', error);
-    return false; // Conservative default
-  }
-};
-
 const TermsAndConditions = ({ plugin }: TermsAndConditionsProps) => {
   const styles = useStyles2(getStyles);
   const { enabled, pinned, jsonData } = plugin.meta;
 
+  // Use centralized config resolution with platform defaults
+  const configWithDefaults = getConfigWithDefaults(jsonData || {});
   const [isRecommenderEnabled, setIsRecommenderEnabled] = useState<boolean>(
-    Boolean(jsonData?.acceptedTermsAndConditions ?? getPlatformSpecificDefault())
+    configWithDefaults.acceptedTermsAndConditions
   );
   const [isSaving, setIsSaving] = useState<boolean>(false);
 
-  // Configuration is now retrieved directly from plugin meta via usePluginContext
-
   // Sync local state with jsonData when it changes (after reload)
   useEffect(() => {
-    const newToggleState = Boolean(jsonData?.acceptedTermsAndConditions ?? getPlatformSpecificDefault());
-    setIsRecommenderEnabled(newToggleState);
-  }, [jsonData?.acceptedTermsAndConditions]);
+    const newConfigWithDefaults = getConfigWithDefaults(jsonData || {});
+    setIsRecommenderEnabled(newConfigWithDefaults.acceptedTermsAndConditions);
+  }, [jsonData]);
 
   const onToggleRecommender = (event: ChangeEvent<HTMLInputElement>) => {
     setIsRecommenderEnabled(event.target.checked);

--- a/src/components/EnableRecommenderBanner/EnableRecommenderBanner.tsx
+++ b/src/components/EnableRecommenderBanner/EnableRecommenderBanner.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2, usePluginContext } from '@grafana/data';
 import { css } from '@emotion/css';
 import { locationService } from '@grafana/runtime';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
-import { isRecommenderEnabled } from '../../constants';
+import { getConfigWithDefaults } from '../../constants';
 
 interface EnableRecommenderBannerProps {
   className?: string;
@@ -14,10 +14,10 @@ interface EnableRecommenderBannerProps {
 export const EnableRecommenderBanner: React.FC<EnableRecommenderBannerProps> = ({ className }) => {
   const styles = useStyles2(getStyles);
   const context = usePluginContext();
-  const pluginConfig = context?.meta?.jsonData || {};
+  const configWithDefaults = getConfigWithDefaults(context?.meta?.jsonData || {});
 
-  // Only show if recommender is disabled (now includes platform-specific defaults)
-  if (isRecommenderEnabled(pluginConfig)) {
+  // Only show if recommender is disabled (uses centralized config with platform defaults)
+  if (configWithDefaults.acceptedTermsAndConditions) {
     return null;
   }
 

--- a/src/components/EnableRecommenderBanner/EnableRecommenderBanner.tsx
+++ b/src/components/EnableRecommenderBanner/EnableRecommenderBanner.tsx
@@ -14,10 +14,10 @@ interface EnableRecommenderBannerProps {
 export const EnableRecommenderBanner: React.FC<EnableRecommenderBannerProps> = ({ className }) => {
   const styles = useStyles2(getStyles);
   const context = usePluginContext();
-  const config = context?.meta?.jsonData || {};
+  const pluginConfig = context?.meta?.jsonData || {};
 
-  // Only show if recommender is disabled
-  if (isRecommenderEnabled(config)) {
+  // Only show if recommender is disabled (now includes platform-specific defaults)
+  if (isRecommenderEnabled(pluginConfig)) {
     return null;
   }
 

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Icon, useStyles2, Card } from '@grafana/ui';
+import { usePluginContext } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import logoSvg from '../../img/logo.svg';
 import { SkeletonLoader } from '../SkeletonLoader';
@@ -14,6 +15,7 @@ import { locationService } from '@grafana/runtime';
 import { getStyles } from '../../styles/context-panel.styles';
 import { useContextPanel } from '../../utils/context';
 import { reportAppInteraction, UserInteraction } from '../../lib/analytics';
+import { getConfigWithDefaults } from '../../constants';
 
 interface ContextPanelState extends SceneObjectState {
   onOpenLearningJourney?: (url: string, title: string) => void;
@@ -57,6 +59,10 @@ export class ContextPanel extends SceneObjectBase<ContextPanelState> {
 }
 
 function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
+  // Get plugin configuration with proper defaults applied
+  const pluginContext = usePluginContext();
+  const configWithDefaults = getConfigWithDefaults(pluginContext?.meta?.jsonData || {});
+
   // Use the simplified context hook
   const {
     contextData,
@@ -128,7 +134,7 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
                   <Icon name="info-circle" />
                   <span>No recommendations available for your current context.</span>
                 </div>
-                <EnableRecommenderBanner />
+                {!configWithDefaults.acceptedTermsAndConditions && <EnableRecommenderBanner />}
               </>
             )}
 
@@ -397,9 +403,10 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
             )}
 
             {/* Show Enable Recommender Banner when recommendations exist but recommender is disabled */}
-            {!isLoadingRecommendations && !recommendationsError && recommendations.length > 0 && (
-              <EnableRecommenderBanner />
-            )}
+            {!isLoadingRecommendations &&
+              !recommendationsError &&
+              recommendations.length > 0 &&
+              !configWithDefaults.acceptedTermsAndConditions && <EnableRecommenderBanner />}
           </div>
         )}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,7 +33,7 @@ export const getConfigWithDefaults = (config: DocsPluginConfig): Required<DocsPl
   docsUsername: config.docsUsername || DEFAULT_DOCS_USERNAME,
   docsPassword: config.docsPassword || DEFAULT_DOCS_PASSWORD,
   tutorialUrl: config.tutorialUrl || DEFAULT_TUTORIAL_URL,
-  acceptedTermsAndConditions: config.acceptedTermsAndConditions ?? DEFAULT_TERMS_ACCEPTED,
+  acceptedTermsAndConditions: config.acceptedTermsAndConditions ?? getPlatformSpecificDefault(),
   termsVersion: config.termsVersion || TERMS_VERSION,
   devMode: config.devMode || DEFAULT_DEV_MODE,
 });
@@ -54,7 +54,7 @@ const getPlatformSpecificDefault = (): boolean => {
 };
 
 export const isRecommenderEnabled = (pluginConfig: DocsPluginConfig): boolean => {
-  return Boolean(pluginConfig.acceptedTermsAndConditions ?? getPlatformSpecificDefault());
+  return getConfigWithDefaults(pluginConfig).acceptedTermsAndConditions;
 };
 
 // Legacy exports for backward compatibility - now require config parameter


### PR DESCRIPTION
This PR fixes an issue where the blue banner appears for cloud users on the installation of the plugin. This was due to the fact that the blue banner never originally looked for the status of the t+c toggle on inital load.