### PR TITLE
allow grafana content + unit tests

### DIFF
--- a/src/utils/link-handler.hook.test.ts
+++ b/src/utils/link-handler.hook.test.ts
@@ -197,10 +197,7 @@ describe('useLinkClickHandler', () => {
       fireEvent.click(grafanaLink);
 
       // Should try to open in app with unstyled URL
-      expect(mockModel.openDocsPage).toHaveBeenCalledWith(
-        expect.stringContaining('unstyled.html'),
-        'Grafana README'
-      );
+      expect(mockModel.openDocsPage).toHaveBeenCalledWith(expect.stringContaining('unstyled.html'), 'Grafana README');
       expect(windowOpen).not.toHaveBeenCalled();
     });
 
@@ -248,11 +245,7 @@ describe('useLinkClickHandler', () => {
 
       fireEvent.click(regularGitHubLink);
 
-      expect(windowOpen).toHaveBeenCalledWith(
-        'https://github.com/grafana/grafana',
-        '_blank',
-        'noopener,noreferrer'
-      );
+      expect(windowOpen).toHaveBeenCalledWith('https://github.com/grafana/grafana', '_blank', 'noopener,noreferrer');
       expect(mockModel.openDocsPage).not.toHaveBeenCalled();
     });
   });

--- a/src/utils/link-handler.hook.test.ts
+++ b/src/utils/link-handler.hook.test.ts
@@ -168,6 +168,95 @@ describe('useLinkClickHandler', () => {
     });
   });
 
+  describe('GitHub Links', () => {
+    let windowOpen: jest.SpyInstance;
+
+    beforeEach(() => {
+      windowOpen = jest.spyOn(window, 'open').mockImplementation();
+    });
+
+    afterEach(() => {
+      windowOpen.mockRestore();
+    });
+
+    it('should open allowed Grafana GitHub URLs in app tabs', () => {
+      renderHook(() =>
+        useLinkClickHandler({
+          contentRef,
+          activeTab: mockModel.getActiveTab(),
+          theme: mockTheme,
+          model: mockModel,
+        })
+      );
+
+      const grafanaLink = document.createElement('a');
+      grafanaLink.href = 'https://raw.githubusercontent.com/grafana/grafana/main/README.md';
+      grafanaLink.textContent = 'Grafana README';
+      contentDiv.appendChild(grafanaLink);
+
+      fireEvent.click(grafanaLink);
+
+      // Should try to open in app with unstyled URL
+      expect(mockModel.openDocsPage).toHaveBeenCalledWith(
+        expect.stringContaining('unstyled.html'),
+        'Grafana README'
+      );
+      expect(windowOpen).not.toHaveBeenCalled();
+    });
+
+    it('should open disallowed URLs in new browser tab', () => {
+      renderHook(() =>
+        useLinkClickHandler({
+          contentRef,
+          activeTab: mockModel.getActiveTab(),
+          theme: mockTheme,
+          model: mockModel,
+        })
+      );
+
+      const disallowedLink = document.createElement('a');
+      disallowedLink.href = 'https://not-whitelisted.com/ExtraContent/README.md';
+      disallowedLink.textContent = 'Disallowed Link';
+      contentDiv.appendChild(disallowedLink);
+
+      fireEvent.click(disallowedLink);
+
+      // Should open in browser, not in app
+      expect(windowOpen).toHaveBeenCalledWith(
+        'https://not-whitelisted.com/ExtraContent/README.md',
+        '_blank',
+        'noopener,noreferrer'
+      );
+      expect(mockModel.openDocsPage).not.toHaveBeenCalled();
+      expect(mockModel.openLearningJourney).not.toHaveBeenCalled();
+    });
+
+    it('should open regular github.com URLs in browser if not in raw allowed list', () => {
+      renderHook(() =>
+        useLinkClickHandler({
+          contentRef,
+          activeTab: mockModel.getActiveTab(),
+          theme: mockTheme,
+          model: mockModel,
+        })
+      );
+
+      const regularGitHubLink = document.createElement('a');
+      regularGitHubLink.href = 'https://github.com/grafana/grafana';
+      regularGitHubLink.textContent = 'Grafana GitHub';
+      contentDiv.appendChild(regularGitHubLink);
+
+      fireEvent.click(regularGitHubLink);
+
+      expect(windowOpen).toHaveBeenCalledWith(
+        'https://github.com/grafana/grafana',
+        '_blank',
+        'noopener,noreferrer'
+      );
+      expect(mockModel.openDocsPage).not.toHaveBeenCalled();
+    });
+  });
+
   describe('External Links', () => {
     it('should open external links in new tab', () => {
       // Mock window.open

--- a/src/utils/link-handler.hook.ts
+++ b/src/utils/link-handler.hook.ts
@@ -7,6 +7,7 @@ import { reportAppInteraction, UserInteraction } from '../lib/analytics';
 const ALLOWED_GITHUB_URLS = [
   'https://raw.githubusercontent.com/moxious/',
   'https://raw.githubusercontent.com/Jayclifford345/',
+  'https://raw.githubusercontent.com/grafana/',
 ];
 
 interface LearningJourneyTab {


### PR DESCRIPTION
We know we (later) want others to be able to contribute guides.  Right now, this is quite awkward because the code is limited to only whitelist Jay & David's repos.  This PR just adds the ability for any repo in Grafana's namespace to be permitted as a guide in the plugin

The reasonining behind this is that we already have reasonable defenses of who can access/modify these repos, and doing it this way allows any other team to write interactive guides in a place that suits them, and have their URLs be recommendable by the recommender.   At present, if for example field team wrote their own guide, docs-plugin would reject it even if the recommender recommended it.

Note that somewhere over the rainbow, we want shortcodes & docs to be the single source of truth.  Docs is spread out among many repos today, so you can see where I'm coming from on that angle as well.