### PR TITLE
report interaction failures can't block main functionality

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -70,7 +70,11 @@ export function reportAppInteraction(
   type: UserInteraction,
   properties: Record<string, string | number | boolean> = {}
 ): void {
-  reportInteraction(createInteractionName(type), properties);
+  try {
+    reportInteraction(createInteractionName(type), properties);
+  } catch (error) {
+    console.warn('Analytics reporting failed:', error);
+  }
 }
 
 // ============================================================================


### PR DESCRIPTION
issue seen on play interactive mode where errors appear in the console with UNAUTHENTICATED users use "Show me" / "Do it"

Not guaranteeing this is the only issue, but this is definitely an issue

<img width="1322" height="336" alt="image" src="https://github.com/user-attachments/assets/85317c48-762a-4063-b458-f61663ee1af2" />
