### PR TITLE
feat(analytics): Rename plugin and update analytic names

### DIFF
--- a/src/components/EnableRecommenderBanner/EnableRecommenderBanner.tsx
+++ b/src/components/EnableRecommenderBanner/EnableRecommenderBanner.tsx
@@ -22,7 +22,7 @@ export const EnableRecommenderBanner: React.FC<EnableRecommenderBannerProps> = (
   }
 
   const handleEnableRecommender = () => {
-    reportAppInteraction(UserInteraction.GeneralPluginFeedbackButton, {
+    reportAppInteraction(UserInteraction.EnableRecommendationsBanner, {
       interaction_location: 'enable_recommender_banner',
       action: 'navigate_to_recommendations_config',
     });

--- a/src/components/FeedbackButton/FeedbackButton.tsx
+++ b/src/components/FeedbackButton/FeedbackButton.tsx
@@ -7,9 +7,16 @@ import { t } from '@grafana/i18n';
 interface FeedbackButtonProps {
   className?: string;
   variant?: 'primary' | 'secondary';
+  contentUrl?: string;
+  contentType?: string;
 }
 
-export const FeedbackButton: React.FC<FeedbackButtonProps> = ({ className, variant = 'primary' }) => {
+export const FeedbackButton: React.FC<FeedbackButtonProps> = ({
+  className,
+  variant = 'primary',
+  contentUrl = '',
+  contentType = '',
+}) => {
   const theme = useTheme2();
   const styles = getFeedbackButtonStyles(theme);
 
@@ -17,6 +24,8 @@ export const FeedbackButton: React.FC<FeedbackButtonProps> = ({ className, varia
     reportAppInteraction(UserInteraction.GeneralPluginFeedbackButton, {
       interaction_location: 'feedback_button',
       panel_type: 'combined_learning_journey',
+      content_url: contentUrl,
+      content_type: contentType,
     });
     window.open(
       'https://docs.google.com/forms/d/e/1FAIpQLSdBvntoRShjQKEOOnRn4_3AWXomKYq03IBwoEaexlwcyjFe5Q/viewform?usp=header',

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -168,23 +168,22 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
                             >
                               <button
                                 onClick={() => {
-                                  // Track analytics based on content type
+                                  // Track analytics - unified event for opening any resource
+                                  reportAppInteraction(UserInteraction.OpenResourceClick, {
+                                    content_title: recommendation.title,
+                                    content_url: recommendation.url,
+                                    content_type: recommendation.type === 'docs-page' ? 'docs' : 'learning-journey',
+                                    interaction_location: 'main_card_button',
+                                    match_accuracy: recommendation.matchAccuracy || 0,
+                                    ...(recommendation.type !== 'docs-page' && {
+                                      total_milestones: recommendation.totalSteps || 0,
+                                    }),
+                                  });
+
+                                  // Open the appropriate content type
                                   if (recommendation.type === 'docs-page') {
-                                    reportAppInteraction(UserInteraction.ViewDocumentationClick, {
-                                      content_title: recommendation.title,
-                                      content_url: recommendation.url,
-                                      interaction_location: 'main_card_button',
-                                      match_accuracy: recommendation.matchAccuracy || 0,
-                                    });
                                     openDocsPage(recommendation.url, recommendation.title);
                                   } else {
-                                    reportAppInteraction(UserInteraction.StartLearningJourneyClick, {
-                                      journey_title: recommendation.title,
-                                      journey_url: recommendation.url,
-                                      interaction_location: 'main_card_button',
-                                      total_milestones: recommendation.totalSteps || 0,
-                                      match_accuracy: recommendation.matchAccuracy || 0,
-                                    });
                                     openLearningJourney(recommendation.url, recommendation.title);
                                   }
                                 }}
@@ -207,14 +206,16 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
                                 <div className={styles.summaryInfo}>
                                   <button
                                     onClick={() => {
-                                      // Track learning journey summary click analytics
-                                      reportAppInteraction(UserInteraction.LearningJourneySummaryClick, {
-                                        journey_title: recommendation.title,
-                                        journey_url: recommendation.url,
-                                        content_type: recommendation.type || 'learning-journey',
+                                      // Track summary click analytics (for both LJ and docs)
+                                      reportAppInteraction(UserInteraction.SummaryClick, {
+                                        content_title: recommendation.title,
+                                        content_url: recommendation.url,
+                                        content_type: recommendation.type === 'docs-page' ? 'docs' : 'learning-journey',
                                         action: recommendation.summaryExpanded ? 'collapse' : 'expand',
                                         match_accuracy: recommendation.matchAccuracy || 0,
-                                        total_milestones: recommendation.totalSteps || 0,
+                                        ...(recommendation.type !== 'docs-page' && {
+                                          total_milestones: recommendation.totalSteps || 0,
+                                        }),
                                       });
 
                                       toggleSummaryExpansion(recommendation.url);
@@ -267,11 +268,11 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
                                               onClick={() => {
                                                 // Track milestone click analytics
                                                 reportAppInteraction(UserInteraction.JumpIntoMilestoneClick, {
-                                                  journey_title: recommendation.title,
+                                                  content_title: recommendation.title,
                                                   milestone_title: milestone.title,
                                                   milestone_number: milestone.number,
                                                   milestone_url: milestone.url,
-                                                  journey_url: recommendation.url,
+                                                  content_url: recommendation.url,
                                                   interaction_location: 'milestone_list',
                                                 });
                                                 openLearningJourney(
@@ -300,23 +301,23 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
                                   <div className={styles.summaryCta}>
                                     <button
                                       onClick={() => {
-                                        // Track analytics for summary CTA buttons
+                                        // Track analytics - unified event for opening any resource
+                                        reportAppInteraction(UserInteraction.OpenResourceClick, {
+                                          content_title: recommendation.title,
+                                          content_url: recommendation.url,
+                                          content_type:
+                                            recommendation.type === 'docs-page' ? 'docs' : 'learning-journey',
+                                          interaction_location: 'summary_cta_button',
+                                          match_accuracy: recommendation.matchAccuracy || 0,
+                                          ...(recommendation.type !== 'docs-page' && {
+                                            total_milestones: recommendation.totalSteps || 0,
+                                          }),
+                                        });
+
+                                        // Open the appropriate content type
                                         if (recommendation.type === 'docs-page') {
-                                          reportAppInteraction(UserInteraction.ViewDocumentationClick, {
-                                            content_title: recommendation.title,
-                                            content_url: recommendation.url,
-                                            interaction_location: 'summary_cta_button',
-                                            match_accuracy: recommendation.matchAccuracy || 0,
-                                          });
                                           openDocsPage(recommendation.url, recommendation.title);
                                         } else {
-                                          reportAppInteraction(UserInteraction.StartLearningJourneyClick, {
-                                            journey_title: recommendation.title,
-                                            journey_url: recommendation.url,
-                                            interaction_location: 'summary_cta_button',
-                                            total_milestones: recommendation.totalSteps || 0,
-                                            match_accuracy: recommendation.matchAccuracy || 0,
-                                          });
                                           openLearningJourney(recommendation.url, recommendation.title);
                                         }
                                       }}
@@ -367,23 +368,22 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
                               <div className={styles.docContent}>
                                 <button
                                   onClick={() => {
-                                    // Track analytics based on content type
+                                    // Track analytics - unified event for opening any resource
+                                    reportAppInteraction(UserInteraction.OpenResourceClick, {
+                                      content_title: item.title,
+                                      content_url: item.url,
+                                      content_type: item.type === 'docs-page' ? 'docs' : 'learning-journey',
+                                      interaction_location: 'other_docs_list',
+                                      match_accuracy: item.matchAccuracy || 0,
+                                      ...(item.type !== 'docs-page' && {
+                                        total_milestones: item.totalSteps || 0,
+                                      }),
+                                    });
+
+                                    // Open the appropriate content type
                                     if (item.type === 'docs-page') {
-                                      reportAppInteraction(UserInteraction.ViewDocumentationClick, {
-                                        content_title: item.title,
-                                        content_url: item.url,
-                                        interaction_location: 'other_docs_list',
-                                        match_accuracy: item.matchAccuracy || 0,
-                                      });
                                       openDocsPage(item.url, item.title);
                                     } else {
-                                      reportAppInteraction(UserInteraction.StartLearningJourneyClick, {
-                                        journey_title: item.title,
-                                        journey_url: item.url,
-                                        interaction_location: 'other_docs_list',
-                                        total_milestones: item.totalSteps || 0,
-                                        match_accuracy: item.matchAccuracy || 0,
-                                      });
                                       openLearningJourney(item.url, item.title);
                                     }
                                   }}

--- a/src/utils/link-handler.hook.test.ts
+++ b/src/utils/link-handler.hook.test.ts
@@ -7,7 +7,7 @@ jest.mock('../lib/analytics', () => ({
   reportAppInteraction: jest.fn(),
   UserInteraction: {
     StartLearningJourneyClick: 'start_learning_journey_click',
-    docs_link_click: 'docs_link_click',
+    OpenExtraResource: 'open_extra_resource',
   },
 }));
 
@@ -323,8 +323,8 @@ describe('useLinkClickHandler', () => {
       expect(reportAppInteraction).toHaveBeenCalledWith(
         UserInteraction.StartLearningJourneyClick,
         expect.objectContaining({
-          journey_title: 'Test Journey',
-          journey_url: 'https://grafana.com/docs/test-journey',
+          content_title: 'Test Journey',
+          content_url: 'https://grafana.com/docs/test-journey',
           total_milestones: 5,
         })
       );

--- a/src/utils/link-handler.hook.ts
+++ b/src/utils/link-handler.hook.ts
@@ -95,8 +95,8 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
         if (milestoneUrl && activeTab) {
           // Track analytics for starting journey
           reportAppInteraction(UserInteraction.StartLearningJourneyClick, {
-            journey_title: activeTab.title,
-            journey_url: activeTab.baseUrl,
+            content_title: activeTab.title,
+            content_url: activeTab.baseUrl,
             interaction_location: 'ready_to_begin_button',
             total_milestones: activeTab.content?.metadata?.learningJourney?.totalMilestones || 0,
           });
@@ -109,8 +109,8 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
           if (firstMilestone.url) {
             // Track analytics for fallback case
             reportAppInteraction(UserInteraction.StartLearningJourneyClick, {
-              journey_title: activeTab.title,
-              journey_url: activeTab.baseUrl,
+              content_title: activeTab.title,
+              content_url: activeTab.baseUrl,
               interaction_location: 'ready_to_begin_button_fallback',
               total_milestones: activeTab.content.milestones.length,
             });
@@ -147,11 +147,13 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
             } else {
               model.openLearningJourney(href, linkText);
             }
-            reportAppInteraction('docs_link_click' as UserInteraction, {
-              link_url: href,
+            reportAppInteraction(UserInteraction.OpenExtraResource, {
+              content_url: href,
+              content_type: 'docs',
               link_text: linkText,
               source_page: activeTab?.content?.url || 'unknown',
               link_type: 'bundled_interactive',
+              interaction_location: 'bundled_link',
             });
             return;
           }
@@ -208,12 +210,15 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
               }
             }
 
-            // Track analytics for docs/tutorials link clicks
-            reportAppInteraction('docs_link_click' as UserInteraction, {
-              link_url: fullUrl,
+            // Track analytics for opening extra resources (docs/tutorials)
+            const contentType = fullUrl.includes('/learning-journeys/') ? 'learning-journey' : 'docs';
+            reportAppInteraction(UserInteraction.OpenExtraResource, {
+              content_url: fullUrl,
+              content_type: contentType,
               link_text: linkText,
               source_page: activeTab?.content?.url || 'unknown',
               link_type: fullUrl.includes('/tutorials/') ? 'tutorial' : 'docs',
+              interaction_location: 'content_link',
             });
           }
           // Handle GitHub links - check if allowed to open in app
@@ -243,11 +248,13 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
                 }
 
                 // Track analytics for allowed GitHub link attempts
-                reportAppInteraction('docs_link_click' as UserInteraction, {
-                  link_url: unstyledUrl,
+                reportAppInteraction(UserInteraction.OpenExtraResource, {
+                  content_url: unstyledUrl,
+                  content_type: 'docs',
                   link_text: linkText,
                   source_page: activeTab?.content?.url || 'unknown',
                   link_type: 'github_allowed_unstyled',
+                  interaction_location: 'github_link',
                 });
               } else {
                 // Even allowed URLs fallback to opening in app without unstyled
@@ -258,11 +265,13 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
                 }
 
                 // Track analytics for allowed GitHub direct attempts
-                reportAppInteraction('docs_link_click' as UserInteraction, {
-                  link_url: resolvedUrl,
+                reportAppInteraction(UserInteraction.OpenExtraResource, {
+                  content_url: resolvedUrl,
+                  content_type: 'docs',
                   link_text: linkText,
                   source_page: activeTab?.content?.url || 'unknown',
                   link_type: 'github_allowed_direct',
+                  interaction_location: 'github_link',
                 });
               }
             } else {
@@ -270,11 +279,13 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
               window.open(resolvedUrl, '_blank', 'noopener,noreferrer');
 
               // Track analytics for GitHub browser opening
-              reportAppInteraction('docs_link_click' as UserInteraction, {
-                link_url: resolvedUrl,
+              reportAppInteraction(UserInteraction.OpenExtraResource, {
+                content_url: resolvedUrl,
+                content_type: 'docs',
                 link_text: linkText,
                 source_page: activeTab?.content?.url || 'unknown',
                 link_type: 'github_browser_external',
+                interaction_location: 'github_link',
               });
             }
           }
@@ -290,12 +301,14 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
 
             const linkText = anchor.textContent?.trim() || 'External Link';
 
-            // Track analytics for external link clicks
-            reportAppInteraction('docs_link_click' as UserInteraction, {
-              link_url: resolvedUrl,
+            // Track analytics for external link clicks opening in browser
+            reportAppInteraction(UserInteraction.OpenExtraResource, {
+              content_url: resolvedUrl,
+              content_type: 'docs',
               link_text: linkText,
               source_page: activeTab?.content?.url || 'unknown',
               link_type: 'external_browser',
+              interaction_location: 'external_link',
             });
           }
         }
@@ -342,13 +355,14 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
             model.openLearningJourney(fullUrl, linkTitle);
           }
 
-          // Track analytics for side journey clicks
-          reportAppInteraction(UserInteraction.OpenSidepathView, {
-            sidepath_title: linkTitle,
-            sidepath_url: fullUrl,
-            source_journey_title: activeTab?.title || 'unknown',
-            source_journey_url: activeTab?.baseUrl || 'unknown',
+          // Track analytics for side journey clicks as extra resource
+          reportAppInteraction(UserInteraction.OpenExtraResource, {
+            content_url: fullUrl,
+            content_type: 'docs',
+            link_text: linkTitle,
             source_page: activeTab?.content?.url || 'unknown',
+            link_type: 'side_journey',
+            interaction_location: 'side_journey_link',
           });
         }
       }
@@ -372,11 +386,13 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
           model.openLearningJourney(fullUrl, linkTitle);
 
           // Track analytics for related journey clicks
-          reportAppInteraction('docs_link_click' as UserInteraction, {
-            link_url: fullUrl,
+          reportAppInteraction(UserInteraction.OpenExtraResource, {
+            content_url: fullUrl,
+            content_type: 'learning-journey',
             link_text: linkTitle,
             source_page: activeTab?.content?.url || 'unknown',
             link_type: 'related_journey',
+            interaction_location: 'related_journey_link',
           });
         }
       }
@@ -391,13 +407,32 @@ export function useLinkClickHandler({ contentRef, activeTab, theme, model }: Use
         });
 
         const buttonText = bottomNavButton.textContent?.trim().toLowerCase();
+        const activeTab = model.getActiveTab();
 
         if (buttonText?.includes('previous') || buttonText?.includes('prev')) {
           if (model.canNavigatePrevious()) {
+            // Track analytics for bottom navigation previous click
+            reportAppInteraction(UserInteraction.MilestoneArrowInteractionClick, {
+              content_title: activeTab?.title || 'unknown',
+              content_url: activeTab?.baseUrl || 'unknown',
+              current_milestone: activeTab?.content?.metadata.learningJourney?.currentMilestone || 0,
+              total_milestones: activeTab?.content?.metadata.learningJourney?.totalMilestones || 0,
+              direction: 'backward',
+              interaction_location: 'bottom_navigation',
+            });
             model.navigateToPreviousMilestone();
           }
         } else if (buttonText?.includes('next')) {
           if (model.canNavigateNext()) {
+            // Track analytics for bottom navigation next click
+            reportAppInteraction(UserInteraction.MilestoneArrowInteractionClick, {
+              content_title: activeTab?.title || 'unknown',
+              content_url: activeTab?.baseUrl || 'unknown',
+              current_milestone: activeTab?.content?.metadata.learningJourney?.currentMilestone || 0,
+              total_milestones: activeTab?.content?.metadata.learningJourney?.totalMilestones || 0,
+              direction: 'forward',
+              interaction_location: 'bottom_navigation',
+            });
             model.navigateToNextMilestone();
           }
         }


### PR DESCRIPTION
This pull request refactors analytics event tracking across the documentation and learning journey panels to unify event types and payloads, making interactions more consistent and easier to analyze. It also improves the `FeedbackButton` component to pass contextual information about the resource being viewed. The most significant changes are grouped below.

**Analytics Event Unification and Refactoring**

* Replaced multiple specific analytics events (such as `ViewDocumentationClick`, `StartLearningJourneyClick`, and `LearningJourneySummaryClick`) with unified events (`OpenResourceClick`, `SummaryClick`, and `OpenExtraResource`) throughout `src/components/docs-panel/context-panel.tsx` and `src/components/docs-panel/docs-panel.tsx`. This includes standardizing payload fields to `content_title`, `content_url`, and `content_type` for both documentation and learning journey resources. [[1]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L171-L187) [[2]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L210-R218) [[3]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L270-R275) [[4]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L303-L319) [[5]](diffhunk://#diff-c35d276630825ce541f4cdd50ca72993c6e919f70c9b15312dab958c50144769L370-L386) [[6]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL625-R631) [[7]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL1021-R1033)
* Updated milestone navigation and tab close events to use `content_title`, `content_url`, and `content_type` instead of journey-specific fields, for consistency across resource types. [[1]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL952-R960) [[2]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL979-R987) [[3]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL715-R719) [[4]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL818-R821)

**Feedback Button Improvements**

* Enhanced the `FeedbackButton` component to accept and report contextual information (`contentUrl`, `contentType`) about the resource being viewed, and passed these props from the docs panel where appropriate. This enables more granular analytics on feedback submissions. [[1]](diffhunk://#diff-046397f7b4701bc1e22dc04b1a86e12710125ab57626d5dd374594ac0ce48530R10-R28) [[2]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL936-R943) [[3]](diffhunk://#diff-a6634bf1e34c7a39cee72774c186a05a64d5e0bc12bed8757c8c154036cce26fL1072-R1086)

**Analytics Event Type Renaming**

* Renamed several analytics event types in `src/lib/analytics.ts` for clarity and to reflect their broader usage (e.g., `DocsPanelScroll` → `PanelScroll`, `OpenSidepathView` → `OpenExtraResource`, etc.).

**Minor Analytics Event Updates**

* Updated the event for enabling recommender banner to use a more specific interaction type (`EnableRecommendationsBanner`).

**Code Clean-up**

* Removed an unused import of `pluginJson` from `src/lib/analytics.ts`.