### PR TITLE
feat(interactive): support nth selector of

### DIFF
--- a/docs/interactive-examples/complex-selectors.md
+++ b/docs/interactive-examples/complex-selectors.md
@@ -1,8 +1,26 @@
 # Complex DOM Selector Support
 
-The enhanced selector engine now supports complex CSS selectors including `:has()` and `:contains()` pseudo-selectors with automatic fallback for older browsers.
+The enhanced selector engine supports complex CSS selectors including `:has()`, `:contains()`, and `:nth-match()` pseudo-selectors with automatic fallback for older browsers.
 
 ## Supported Complex Selectors
+
+### `:nth-match()` Pseudo-Selector (Custom)
+
+Finds the Nth occurrence of an element matching the selector globally. This is different from `:nth-child()` which only works within a parent.
+
+```html
+<!-- Get the 3rd chart on the page, regardless of parent structure -->
+<li class="interactive" data-targetaction="highlight" data-reftarget='div[data-testid="uplot-main-div"]:nth-match(3)'>
+  Highlight the third chart
+</li>
+
+<!-- Get the 2nd save button -->
+<li class="interactive" data-targetaction="button" data-reftarget="button.save-btn:nth-match(2)">
+  Click second save button
+</li>
+```
+
+**Note:** See [nth-selectors.md](./nth-selectors.md) for detailed explanation of `:nth-child()` vs `:nth-match()` differences.
 
 ### `:contains()` Pseudo-Selector
 

--- a/docs/interactive-examples/nth-selectors.md
+++ b/docs/interactive-examples/nth-selectors.md
@@ -1,0 +1,127 @@
+# Understanding :nth-child vs :nth-match Selectors
+
+## The Problem with :nth-child()
+
+When you write a selector like:
+
+```css
+div[data-testid='uplot-main-div']: nth-child(3);
+```
+
+You might expect it to find "the 3rd div with that test ID", but **that's not how CSS works**.
+
+### What :nth-child() Actually Does
+
+`:nth-child(3)` means: **"Match this element ONLY IF it is the 3rd child of its parent"**
+
+#### Example That Fails:
+
+```html
+<div class="parent1">
+  <div data-testid="uplot-main-div">First uplot</div>
+</div>
+<div class="parent2">
+  <div data-testid="uplot-main-div">Second uplot</div>
+</div>
+<div class="parent3">
+  <div data-testid="uplot-main-div">Third uplot</div>
+</div>
+```
+
+Using `div[data-testid='uplot-main-div']:nth-child(3)` returns **nothing** because:
+
+- The first div is the 1st child of parent1 ❌
+- The second div is the 1st child of parent2 ❌
+- The third div is the 1st child of parent3 ❌
+- None of them are the 3rd child of their parent!
+
+#### Example That Works:
+
+```html
+<div class="parent">
+  <span>First child</span>
+  <p>Second child</p>
+  <div data-testid="uplot-main-div">Third child - this matches!</div>
+</div>
+```
+
+Now `div[data-testid='uplot-main-div']:nth-child(3)` **works** because the div is actually the 3rd child of its parent.
+
+### What about :nth-of-type()?
+
+`:nth-of-type(3)` means: **"Match this element ONLY IF it is the 3rd element of its TYPE within its parent"**
+
+This has the same limitation - it still looks at position within a parent, not globally.
+
+## The Solution: :nth-match()
+
+We've added a **custom pseudo-selector** `:nth-match(n)` that does what you probably want:
+
+**`:nth-match(3)` means: "Find ALL elements matching this selector, then return the 3rd one"**
+
+### Usage Examples
+
+#### Get the 3rd uplot globally:
+
+```html
+<li class="interactive" data-targetaction="highlight" data-reftarget='div[data-testid="uplot-main-div"]:nth-match(3)'>
+  Highlight the third chart on the page
+</li>
+```
+
+#### Get the 1st occurrence (equivalent to :first-of-type globally):
+
+```html
+<li class="interactive" data-targetaction="focus" data-reftarget='div[data-testid="uplot-main-div"]:nth-match(1)'>
+  Focus on the first chart
+</li>
+```
+
+#### Get the 2nd button with a specific class:
+
+```html
+<li class="interactive" data-targetaction="button" data-reftarget="button.save-button:nth-match(2)">
+  Click the second save button
+</li>
+```
+
+## Quick Reference
+
+| Selector             | What it means                                             | Use case                                                             |
+| -------------------- | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| `div:nth-child(3)`   | Element that is the 3rd child of its parent               | When you know the element's position in its parent                   |
+| `div:nth-of-type(3)` | Element that is the 3rd div child of its parent           | When you know the element's position among siblings of the same type |
+| `div:nth-match(3)`   | The 3rd div matching this selector in the entire document | **When you want the nth occurrence globally** ⭐                     |
+
+## Browser Support
+
+- `:nth-child()` and `:nth-of-type()` are standard CSS and work natively in all browsers
+- `:nth-match()` is a custom implementation that uses `querySelectorAll` under the hood and works in all browsers through our enhanced selector engine
+
+## Troubleshooting
+
+### "No elements found" error
+
+If you're getting "No elements found" when using `:nth-match(3)`, check:
+
+1. **Does the base selector find any elements?**
+
+   ```javascript
+   // In browser console:
+   document.querySelectorAll('div[data-testid="uplot-main-div"]').length;
+   ```
+
+2. **Are there at least 3 matches?**
+   - `:nth-match(3)` needs at least 3 elements to exist
+   - The error message will tell you how many were found: `wanted 3, found 2`
+
+3. **Are the elements loaded yet?**
+   - Add requirements to wait for page load: `data-requirements="location-match:/dashboards"`
+
+### Still having issues?
+
+Check the browser console for detailed error messages. The enhanced selector engine logs:
+
+- What selector was used
+- How many elements were found
+- Whether fallback implementations were used


### PR DESCRIPTION
This pull request adds support for a new custom pseudo-selector, `:nth-match()`, to the enhanced selector engine and its documentation and tests. The `:nth-match()` selector allows users to select the Nth occurrence of an element matching a selector globally, addressing limitations of native CSS selectors like `:nth-child()` and `:nth-of-type()`. The documentation is updated to explain the difference between these selectors, and new tests are added to validate the behavior.

**Complex Selector Engine Improvements:**

* Added support for the custom `:nth-match()` pseudo-selector in the enhanced selector engine, enabling selection of the Nth matching element globally. [[1]](diffhunk://#diff-6b22b00f7204efda4d2eeb90ed84189cc8cd422576f4c30b99cf706e2e565cf6L66-R71) [[2]](diffhunk://#diff-6b22b00f7204efda4d2eeb90ed84189cc8cd422576f4c30b99cf706e2e565cf6L87-R97)

**Documentation Updates:**

* Updated `complex-selectors.md` to include `:nth-match()` in the list of supported selectors and provide usage examples.
* Added a new `nth-selectors.md` document explaining the differences between `:nth-child()`, `:nth-of-type()`, and the new `:nth-match()` selector, including troubleshooting tips and browser support notes.

**Testing Enhancements:**

* Refactored and extended tests in `enhanced-selector.test.ts` to cover the new `:nth-match()` selector, its edge cases, and to clarify the limitations of native selectors versus the enhanced engine.

These changes improve the flexibility and clarity of DOM element selection in interactive examples and automated tests, making it easier to target specific elements regardless of their parent structure.