### PR TITLE
fix(analytics): fixed total

### DIFF
--- a/src/utils/docs-retrieval/content-renderer.tsx
+++ b/src/utils/docs-retrieval/content-renderer.tsx
@@ -178,10 +178,14 @@ function ContentProcessor({ html, contentType, baseUrl, onReady }: ContentProces
 
   // Reset interactive counters only when content changes (not on every render)
   // This must run BEFORE parsing to ensure clean state for section registration
-  // Using useEffect with layout timing to ensure it runs before render
-  useEffect(() => {
-    resetInteractiveCounters();
-  }, [html]);
+  useMemo(
+    () => {
+      resetInteractiveCounters();
+      return null;
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [html]
+  );
 
   // Parse HTML with fail-fast error handling (memoized to avoid re-parsing on every render)
   const parseResult: ContentParseResult = useMemo(() => parseHTMLToComponents(html, baseUrl), [html, baseUrl]);


### PR DESCRIPTION
This pull request updates the way interactive counters are reset in the `ContentProcessor` component to improve reliability and ensure the reset occurs before parsing the HTML content. The main change is replacing the use of `useEffect` with `useMemo`, which better aligns with the intended timing and avoids unnecessary reruns.

**React hook usage improvement:**

* Replaced `useEffect` with `useMemo` for resetting interactive counters in the `ContentProcessor` component, ensuring the reset happens before parsing and only when `html` changes.