### PR TITLE
feat(interactive): added docs link interceptor and fixed guided journey

### DIFF
--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -78,6 +78,27 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
     onOpenDocsPage: model.state.onOpenDocsPage,
   });
 
+  // Listen for auto-open events from global link interceptor
+  React.useEffect(() => {
+    const handleAutoOpen = (event: Event) => {
+      const customEvent = event as CustomEvent<{ url: string; title: string; origin: string }>;
+      const { url, title } = customEvent.detail;
+
+      // Determine if it's a learning journey or regular docs page
+      if (url.includes('/learning-journeys/')) {
+        openLearningJourney(url, title);
+      } else {
+        openDocsPage(url, title);
+      }
+    };
+
+    document.addEventListener('pathfinder-auto-open-docs', handleAutoOpen);
+
+    return () => {
+      document.removeEventListener('pathfinder-auto-open-docs', handleAutoOpen);
+    };
+  }, [openLearningJourney, openDocsPage]);
+
   const { recommendations, isLoading, recommendationsError } = contextData;
 
   const styles = useStyles2(getStyles);

--- a/src/components/docs-panel/context-panel.tsx
+++ b/src/components/docs-panel/context-panel.tsx
@@ -78,26 +78,8 @@ function ContextPanelRenderer({ model }: SceneComponentProps<ContextPanel>) {
     onOpenDocsPage: model.state.onOpenDocsPage,
   });
 
-  // Listen for auto-open events from global link interceptor
-  React.useEffect(() => {
-    const handleAutoOpen = (event: Event) => {
-      const customEvent = event as CustomEvent<{ url: string; title: string; origin: string }>;
-      const { url, title } = customEvent.detail;
-
-      // Determine if it's a learning journey or regular docs page
-      if (url.includes('/learning-journeys/')) {
-        openLearningJourney(url, title);
-      } else {
-        openDocsPage(url, title);
-      }
-    };
-
-    document.addEventListener('pathfinder-auto-open-docs', handleAutoOpen);
-
-    return () => {
-      document.removeEventListener('pathfinder-auto-open-docs', handleAutoOpen);
-    };
-  }, [openLearningJourney, openDocsPage]);
+  // Note: Auto-open event listener moved to CombinedPanelRenderer to avoid remounting issues
+  // ContextPanelRenderer remounts when tabs change, causing listener cleanup
 
   const { recommendations, isLoading, recommendationsError } = contextData;
 

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -494,6 +494,31 @@ function CombinedPanelRenderer({ model }: SceneComponentProps<CombinedLearningJo
   React.useEffect(() => {
     addGlobalModalStyles();
   }, []);
+
+  // Listen for auto-open events from global link interceptor
+  // Place this HERE (not in ContextPanelRenderer) to avoid component remounting issues
+  React.useEffect(() => {
+    const handleAutoOpen = (event: Event) => {
+      const customEvent = event as CustomEvent<{ url: string; title: string; origin: string }>;
+      const { url, title } = customEvent.detail;
+
+      // Always create a new tab for each intercepted link
+      // Call the model method directly to ensure new tabs are created
+      if (url.includes('/learning-journeys/')) {
+        model.openLearningJourney(url, title);
+      } else {
+        model.openDocsPage(url, title);
+      }
+    };
+
+    // Listen for all auto-open events
+    document.addEventListener('pathfinder-auto-open-docs', handleAutoOpen);
+
+    return () => {
+      document.removeEventListener('pathfinder-auto-open-docs', handleAutoOpen);
+    };
+  }, [model]); // Only model as dependency - this component doesn't remount on tab changes
+
   const { tabs, activeTabId, contextPanel } = model.useState();
   // removed — using restored custom overflow state below
 

--- a/src/components/docs-panel/docs-panel.tsx
+++ b/src/components/docs-panel/docs-panel.tsx
@@ -667,7 +667,7 @@ function CombinedPanelRenderer({ model }: SceneComponentProps<CombinedLearningJo
   // ContentRenderer renders the content with styling applied via CSS classes
 
   return (
-    <div id="CombinedLearningJourney" className={styles.container}>
+    <div id="CombinedLearningJourney" className={styles.container} data-pathfinder-content="true">
       <div className={styles.topBar}>
         <div className={styles.tabBar}>
           <div className={styles.tabList} ref={tabListRef}>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,9 @@ export const DEFAULT_AUTO_DETECTION_DEBOUNCE = 100; // ms
 export const DEFAULT_REQUIREMENTS_CHECK_TIMEOUT = 3000; // ms
 export const DEFAULT_GUIDED_STEP_TIMEOUT = 30000; // ms (30 seconds)
 
+// Global Link Interception defaults
+export const DEFAULT_INTERCEPT_GLOBAL_DOCS_LINKS = false; // Opt-in feature
+
 // Configuration interface
 export interface DocsPluginConfig {
   recommenderServiceUrl?: string;
@@ -35,6 +38,8 @@ export interface DocsPluginConfig {
   autoDetectionDebounce?: number;
   requirementsCheckTimeout?: number;
   guidedStepTimeout?: number;
+  // Global Link Interception
+  interceptGlobalDocsLinks?: boolean;
 }
 
 // Helper functions to get configuration values with defaults
@@ -52,6 +57,8 @@ export const getConfigWithDefaults = (config: DocsPluginConfig): Required<DocsPl
   autoDetectionDebounce: config.autoDetectionDebounce ?? DEFAULT_AUTO_DETECTION_DEBOUNCE,
   requirementsCheckTimeout: config.requirementsCheckTimeout ?? DEFAULT_REQUIREMENTS_CHECK_TIMEOUT,
   guidedStepTimeout: config.guidedStepTimeout ?? DEFAULT_GUIDED_STEP_TIMEOUT,
+  // Global Link Interception
+  interceptGlobalDocsLinks: config.interceptGlobalDocsLinks ?? DEFAULT_INTERCEPT_GLOBAL_DOCS_LINKS,
 });
 
 /**

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -48,6 +48,9 @@ export enum UserInteraction {
   DoItButtonClick = 'do_it_button_click',
   DoSectionButtonClick = 'do_section_button_click',
   StepAutoCompleted = 'step_auto_completed',
+
+  // Global Link Interception
+  GlobalDocsLinkIntercepted = 'global_docs_link_intercepted',
 }
 
 // ============================================================================

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -84,17 +84,7 @@ plugin.addComponent({
     // Callback to open docs link in Pathfinder sidebar
     const handleOpenDocsLink = useCallback((url: string, title: string) => {
       try {
-        // First, dispatch custom event to tell context panel to open this URL
-        const autoOpenEvent = new CustomEvent('pathfinder-auto-open-docs', {
-          detail: {
-            url,
-            title,
-            origin: 'global_link_interceptor',
-          },
-        });
-        document.dispatchEvent(autoOpenEvent);
-
-        // Then, open the extension sidebar (if not already open)
+        // First, ensure the extension sidebar is open
         const appEvents = getAppEvents();
         appEvents.publish({
           type: 'open-extension-sidebar',
@@ -103,6 +93,19 @@ plugin.addComponent({
             componentTitle: 'Grafana Pathfinder',
           },
         });
+
+        // Then, after a brief delay to ensure sidebar is mounted, dispatch event to open the URL
+        // This ensures the context panel is ready to receive the event
+        setTimeout(() => {
+          const autoOpenEvent = new CustomEvent('pathfinder-auto-open-docs', {
+            detail: {
+              url,
+              title,
+              origin: 'global_link_interceptor',
+            },
+          });
+          document.dispatchEvent(autoOpenEvent);
+        }, 150);
       } catch (error) {
         console.error('Failed to open docs link in Pathfinder:', error);
       }

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -1,10 +1,18 @@
-import { AppPlugin, type AppRootProps, PluginExtensionPoints, BusEventWithPayload } from '@grafana/data';
+import {
+  AppPlugin,
+  type AppRootProps,
+  PluginExtensionPoints,
+  BusEventWithPayload,
+  usePluginContext,
+} from '@grafana/data';
 import { LoadingPlaceholder } from '@grafana/ui';
 import { getAppEvents } from '@grafana/runtime';
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense, lazy, useCallback, useMemo } from 'react';
 import { reportAppInteraction, UserInteraction } from './lib/analytics';
 import { initPluginTranslations } from '@grafana/i18n';
 import pluginJson from './plugin.json';
+import { useGlobalLinkInterceptor } from './utils/global-link-interceptor.hook';
+import { getConfigWithDefaults } from './constants';
 
 // Initialize translations
 await initPluginTranslations(pluginJson.id);
@@ -67,6 +75,45 @@ plugin.addComponent({
   title: 'Grafana Pathfinder',
   description: 'Opens Grafana Pathfinder',
   component: function ContextSidebar() {
+    // Get plugin configuration
+    const pluginContext = usePluginContext();
+    const config = useMemo(() => {
+      return getConfigWithDefaults(pluginContext?.meta?.jsonData || {});
+    }, [pluginContext?.meta?.jsonData]);
+
+    // Callback to open docs link in Pathfinder sidebar
+    const handleOpenDocsLink = useCallback((url: string, title: string) => {
+      try {
+        // First, dispatch custom event to tell context panel to open this URL
+        const autoOpenEvent = new CustomEvent('pathfinder-auto-open-docs', {
+          detail: {
+            url,
+            title,
+            origin: 'global_link_interceptor',
+          },
+        });
+        document.dispatchEvent(autoOpenEvent);
+
+        // Then, open the extension sidebar (if not already open)
+        const appEvents = getAppEvents();
+        appEvents.publish({
+          type: 'open-extension-sidebar',
+          payload: {
+            pluginId: pluginJson.id,
+            componentTitle: 'Grafana Pathfinder',
+          },
+        });
+      } catch (error) {
+        console.error('Failed to open docs link in Pathfinder:', error);
+      }
+    }, []);
+
+    // Enable global link interception if configured
+    useGlobalLinkInterceptor({
+      onOpenDocsLink: handleOpenDocsLink,
+      enabled: config.interceptGlobalDocsLinks,
+    });
+
     React.useEffect(() => {
       reportAppInteraction(UserInteraction.DocsPanelInteraction, {
         action: 'open',

--- a/src/styles/interactive.styles.ts
+++ b/src/styles/interactive.styles.ts
@@ -1084,6 +1084,35 @@ export const addGlobalInteractiveStyles = () => {
       border-bottom: 8px solid var(--grafana-colors-background-primary, #1f1f23);
     }
 
+    /* Step checklist in guided comment tooltips */
+    .interactive-comment-steps-list {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      margin-bottom: 10px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid var(--grafana-colors-border-weak, #404040);
+    }
+
+    .interactive-comment-step-item {
+      font-size: 12px;
+      line-height: 1.3;
+      color: var(--grafana-colors-text-secondary, #999999);
+      padding: 2px 0;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .interactive-comment-step-item.interactive-comment-step-current {
+      color: var(--grafana-colors-text-primary, #d9d9d9);
+      font-weight: 500;
+      background: rgba(255, 193, 7, 0.15);
+      padding: 4px 6px;
+      margin: -2px -4px;
+      border-radius: 3px;
+    }
+
     /* Hide interactive comment spans - they're extracted as metadata */
     span.interactive-comment {
       display: none !important;

--- a/src/utils/docs-retrieval/components/interactive/interactive-multi-step.tsx
+++ b/src/utils/docs-retrieval/components/interactive/interactive-multi-step.tsx
@@ -124,6 +124,7 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
       requirements,
       objectives,
       onComplete,
+      skippable = false, // Whether this multi-step can be skipped
       stepDelay = INTERACTIVE_CONFIG.delays.multiStep.defaultStepDelay, // Default delay between steps
       resetTrigger,
       stepIndex,
@@ -618,6 +619,35 @@ export const InteractiveMultiStep = forwardRef<{ executeStep: () => Promise<bool
                 title={getButtonTitle()}
               >
                 {getButtonText()}
+              </Button>
+            )}
+
+            {/* Show "Skip" button when multi-step is skippable (always available, not just on error) */}
+            {skippable && !isCompletedWithObjectives && (
+              <Button
+                onClick={async () => {
+                  if (checker.markSkipped) {
+                    await checker.markSkipped();
+
+                    // Mark as completed and notify parent
+                    setIsLocallyCompleted(true);
+
+                    if (onStepComplete && stepId) {
+                      onStepComplete(stepId);
+                    }
+
+                    if (onComplete) {
+                      onComplete();
+                    }
+                  }
+                }}
+                disabled={disabled || isAnyActionRunning}
+                size="sm"
+                variant="secondary"
+                className="interactive-step-skip-btn"
+                title="Skip this multi-step without executing"
+              >
+                Skip
               </Button>
             )}
           </div>

--- a/src/utils/docs-retrieval/components/interactive/interactive-step.tsx
+++ b/src/utils/docs-retrieval/components/interactive/interactive-step.tsx
@@ -543,6 +543,33 @@ export const InteractiveStep = forwardRef<
                     : 'Do it'}
               </Button>
             )}
+
+            {/* Show "Skip" button when step is skippable (always available, not just on error) */}
+            {skippable && !isCompletedWithObjectives && (
+              <Button
+                onClick={async () => {
+                  if (checker.markSkipped) {
+                    await checker.markSkipped();
+
+                    // Notify parent section of step completion (skipped counts as completed)
+                    if (onStepComplete && stepId) {
+                      onStepComplete(stepId);
+                    }
+
+                    if (onComplete) {
+                      onComplete();
+                    }
+                  }
+                }}
+                disabled={disabled || isAnyActionRunning}
+                size="sm"
+                variant="secondary"
+                className="interactive-step-skip-btn"
+                title="Skip this step without executing"
+              >
+                Skip
+              </Button>
+            )}
           </div>
 
           {isCompletedWithObjectives && (

--- a/src/utils/docs-retrieval/content-renderer.tsx
+++ b/src/utils/docs-retrieval/content-renderer.tsx
@@ -148,6 +148,7 @@ export function ContentRenderer({ content, onContentReady, className, containerR
     <div
       ref={activeRef}
       className={className}
+      data-pathfinder-content="true"
       style={{
         display: 'flex',
         flexDirection: 'column',

--- a/src/utils/global-link-interceptor.hook.ts
+++ b/src/utils/global-link-interceptor.hook.ts
@@ -1,0 +1,145 @@
+import { useEffect } from 'react';
+import { reportAppInteraction, UserInteraction } from '../lib/analytics';
+
+interface GlobalLinkInterceptorProps {
+  onOpenDocsLink: (url: string, title: string) => void;
+  enabled?: boolean;
+}
+
+/**
+ * Determines if a URL is a supported Grafana docs link that can be opened in Pathfinder
+ */
+function isSupportedDocsUrl(url: string): boolean {
+  try {
+    // Check if it's a Grafana docs, tutorial, or learning journey URL
+    if (
+      url.includes('grafana.com/docs/') ||
+      url.includes('grafana.com/tutorials/') ||
+      url.includes('grafana.com/learning-journeys/')
+    ) {
+      return true;
+    }
+
+    // Also support relative paths that might be Grafana docs
+    if (url.startsWith('/docs/') || url.startsWith('/tutorials/') || url.startsWith('/learning-journeys/')) {
+      return true;
+    }
+
+    return false;
+  } catch (error) {
+    console.warn('Error checking if URL is supported:', error);
+    return false;
+  }
+}
+
+/**
+ * Global link interceptor that catches documentation links across all of Grafana
+ * and opens them in Pathfinder instead of a new browser tab.
+ *
+ * Features:
+ * - Respects user intent (Ctrl/Cmd+Click opens in new tab)
+ * - Only intercepts supported docs URLs
+ * - Avoids double-handling of links inside Pathfinder content
+ * - Opt-in feature (disabled by default)
+ *
+ * @param onOpenDocsLink - Callback to open docs link in Pathfinder
+ * @param enabled - Whether to enable global link interception (default: false)
+ */
+export function useGlobalLinkInterceptor({ onOpenDocsLink, enabled = false }: GlobalLinkInterceptorProps) {
+  useEffect(() => {
+    // Feature is disabled, don't attach listener
+    if (!enabled) {
+      return;
+    }
+
+    const handleGlobalClick = (event: MouseEvent) => {
+      // Only intercept if it's a left-click without modifiers
+      // Allow Ctrl/Cmd+Click, Shift+Click, Alt+Click and middle-click to open in new tab as normal
+      if (
+        event.button !== 0 || // Not a left-click
+        event.ctrlKey || // Ctrl+Click (Windows/Linux)
+        event.metaKey || // Cmd+Click (Mac)
+        event.shiftKey || // Shift+Click
+        event.altKey // Alt+Click
+      ) {
+        return;
+      }
+
+      const target = event.target as HTMLElement;
+      const anchor = target.closest('a[href]') as HTMLAnchorElement;
+
+      if (!anchor) {
+        return;
+      }
+
+      const href = anchor.getAttribute('href');
+      if (!href) {
+        return;
+      }
+
+      // Skip if the link is already inside Pathfinder plugin content
+      // This prevents double-handling of links that are already managed by useLinkClickHandler
+      if (anchor.closest('[data-pathfinder-content]')) {
+        return;
+      }
+
+      // Resolve relative URLs to full URLs
+      let fullUrl: string;
+      try {
+        if (href.startsWith('http://') || href.startsWith('https://')) {
+          // Already a full URL
+          fullUrl = href;
+        } else if (href.startsWith('/')) {
+          // Absolute path - assume it's on grafana.com domain
+          fullUrl = `https://grafana.com${href}`;
+        } else if (href.startsWith('#')) {
+          // Fragment link - skip it (let browser handle)
+          return;
+        } else {
+          // Relative path - resolve against current location
+          fullUrl = new URL(href, window.location.href).href;
+        }
+      } catch (error) {
+        console.warn('Failed to resolve URL:', href, error);
+        return;
+      }
+
+      // Check if this is a supported docs URL
+      if (isSupportedDocsUrl(fullUrl)) {
+        // CRITICAL: Prevent default navigation IMMEDIATELY and stop all propagation
+        // This must happen before anything else to block the link from opening
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+
+        // Also remove target="_blank" to prevent new tab opening
+        if (anchor.hasAttribute('target')) {
+          anchor.removeAttribute('target');
+        }
+
+        // Extract link text for tab title
+        const linkText = anchor.textContent?.trim() || anchor.getAttribute('aria-label') || 'Documentation';
+
+        // Track analytics for intercepted link
+        reportAppInteraction(UserInteraction.GlobalDocsLinkIntercepted, {
+          content_url: fullUrl,
+          link_text: linkText,
+          source_location: 'global',
+          timestamp: Date.now(),
+        });
+
+        // Open in Pathfinder
+        onOpenDocsLink(fullUrl, linkText);
+      }
+    };
+
+    // Add listener in capture phase to catch events before they bubble
+    // This ensures we intercept the click before any other handlers
+    document.addEventListener('click', handleGlobalClick, { capture: true });
+
+    // Cleanup on unmount
+    return () => {
+      document.removeEventListener('click', handleGlobalClick, { capture: true });
+    };
+  }, [onOpenDocsLink, enabled]);
+}


### PR DESCRIPTION
This pull request introduces two main improvements: a new opt-in feature for globally intercepting documentation links and opening them in the Pathfinder sidebar, and enhanced user feedback during guided tutorials by displaying step progress. It also includes supporting UI and configuration changes, as well as minor style and analytics updates.

**Global Documentation Link Interception**

* Added a new configuration option `interceptGlobalDocsLinks` to enable/disable global interception of documentation links, defaulting to off (`false`). This allows users to open Grafana docs links anywhere in the app directly in the Pathfinder sidebar instead of a new tab. The option is exposed in the configuration form with explanatory UI and an info alert. [[1]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0R12) [[2]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0R33-R34) [[3]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0R52) [[4]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0R109-R115) [[5]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0R128) [[6]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0R242-R273) [[7]](diffhunk://#diff-0d4959df960020c0bcbe62ba3c8fd64dbb15ae14111ad176b639ae881ce7ebe0R296-R307) [[8]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R22-R24) [[9]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R41-R42) [[10]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R60-R61)
* Implemented the global link interception logic in both the main app and the sidebar extension, using the `useGlobalLinkInterceptor` hook and a custom event to communicate with the context panel. [[1]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57L2-R10) [[2]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57R25-L25) [[3]](diffhunk://#diff-9627dc66df62a6649464029eae47b9a8f3d529356eb7df1a0d21b44d0538fe57L50-R87) [[4]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560L1-R15) [[5]](diffhunk://#diff-f9f6328570564a8c2d8bcd80ce4f7a1b84a8805202c498fa2f44a1e650c1d560R78-R116)
* The context panel listens for these custom events and opens the appropriate docs or learning journey page, ensuring seamless navigation.
* Added a new analytics event for tracking when a global docs link is intercepted.

**Guided Tutorial Step Progress**

* Enhanced the guided tutorial handler to track and display which steps have been completed, and to show a checklist of steps in the comment tooltip for better user feedback. [[1]](diffhunk://#diff-35ab349687a78bd8b6885bd881c94a77d17e3fc2222e0ace92797226401698b7R26) [[2]](diffhunk://#diff-35ab349687a78bd8b6885bd881c94a77d17e3fc2222e0ace92797226401698b7R57-R63) [[3]](diffhunk://#diff-35ab349687a78bd8b6885bd881c94a77d17e3fc2222e0ace92797226401698b7R98-R102) [[4]](diffhunk://#diff-35ab349687a78bd8b6885bd881c94a77d17e3fc2222e0ace92797226401698b7L212-R234)
* Adjusted the instructional messages to remove redundant step numbers, as step progress is now visually indicated.
* Added new CSS styles for the guided step checklist and current step highlighting in tooltips.

**Minor Improvements**

* Added a `data-pathfinder-content="true"` attribute to the combined learning journey panel for future targeting or identification.

These changes collectively improve the plugin's usability, especially for users who want Pathfinder to handle docs navigation globally and for those following guided tutorials.